### PR TITLE
Update readme and fix json decode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # gh-auth
 
-This is a php port of Chris Hunt's
+This is a `go` port of Chris Hunt's
 [github-auth](https://github.com/chrishunt/github-auth).  I did this
-mainly to learn `go` programming language.
+mainly to learn the `go` programming language.
 
 ### Pairing with strangers has never been so good.
 

--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main //import "github.com/marcusmyers/gh-auth"
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -77,12 +76,9 @@ func addUser(c *cli.Context) error {
 	}
 	dec := json.NewDecoder(resp.Body)
 	s := make([]SSHKey, 0, 10)
-	for {
-		if err := dec.Decode(&s); err == io.EOF {
-			break
-		} else if err != nil {
-			log.Fatal(err)
-		}
+	json_err := dec.Decode(&s)
+	if json_err != nil {
+		log.Fatal(json_err)
 	}
 	resp.Body.Close()
 	str, numKeys := _returnStrKeys(s, user)

--- a/main_test.go
+++ b/main_test.go
@@ -15,17 +15,9 @@ func init() {
 	url = "https://api.github.com"
 }
 
-func testReadAuthorizedKeys(t *testing.T) {
-	content, err := readAuthorizedKeys()
+func TestReadAuthorizedKeys(t *testing.T) {
+	_, err := readAuthorizedKeys()
 	if err != nil {
 		t.Error("Expecting to read the autorized_keys file, but got", err)
-	}
-}
-
-func testGettingUsers(t *testing.T) {
-	expected := "crwenner"
-	actual := _getUsers("Admaksdue== crwenner")
-	if expected != actual[0] {
-		t.Error("Expecting crwenner, but got", actual)
 	}
 }


### PR DESCRIPTION
This commit updates the readme to say `go` instead of `php` and does a
better job of decoding json.